### PR TITLE
Fix error when using as CommonJS module

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
   "exports": {
     ".": {
       "import": "./dist/esm/index.mjs",
-      "node": "./dist/cjs/index.cjs",
       "require": "./dist/cjs/index.cjs",
-      "default": "./dist/esm/index.mjs",
       "types": "./dist/types/index.d.ts"
     }
   },

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   "peerDependencies": {
     "@remscodes/renault-api": "^1.2.2",
     "dayjs": "^1.11.10",
-    "drino": "^1.7.0",
-    "thror": "^1.0.1"
+    "drino": "^1.8.2",
+    "thror": "^1.0.2"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
   },
   "keywords": [
     "renault",
+    "api",
     "http"
   ],
-  "packageManager": "pnpm@8.11.0"
+  "packageManager": "pnpm@8.13.1",
+  "sideEffects": false
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/remscodes/renault-api-client"
   },
   "engines": {
-    "node": ">=18.13.0"
+    "node": "^20.9.0"
   },
   "peerDependencies": {
     "@remscodes/renault-api": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ dependencies:
     specifier: ^1.11.10
     version: 1.11.10
   drino:
-    specifier: ^1.7.0
-    version: 1.7.0
+    specifier: ^1.8.2
+    version: 1.8.2(thror@1.0.2)
   thror:
-    specifier: ^1.0.1
-    version: 1.0.1
+    specifier: ^1.0.2
+    version: 1.0.2
 
 devDependencies:
   '@rollup/plugin-terser':
@@ -552,11 +552,13 @@ packages:
       ms: 2.1.2
     dev: true
 
-  /drino@1.7.0:
-    resolution: {integrity: sha512-wF+utu5tsMz8S6cvtCup0oGLNUSAMstydTgQtxFr4MDir0t+AmtfK+mx/eaviO+JrVX5K0y/fGnk4qaAxPCeMA==}
-    engines: {node: '>=18.13.0'}
+  /drino@1.8.2(thror@1.0.2):
+    resolution: {integrity: sha512-eQnh3CdkdWD5StoFA5Rn7Lv5k2lmNvDT8qrTyUG9NBwTMp4XpEndJDPm2G15l57+SnzhFxu+q5PoWABofX9eiw==}
+    engines: {node: ^20.9.0}
+    peerDependencies:
+      thror: ^1.0.2
     dependencies:
-      thror: 1.0.1
+      thror: 1.0.2
     dev: false
 
   /duplexer@0.1.2:
@@ -827,9 +829,9 @@ packages:
       source-map-support: 0.5.21
     dev: true
 
-  /thror@1.0.1:
-    resolution: {integrity: sha512-9eQflGxhPv2NJr0c7aRjLnYzRmsEQcfMCGFb4SVKg3+CXcRqnD9cAwErlIZZUweNOkBomr4kPZJnZ4dMwMH1Iw==}
-    engines: {node: '>=18.0.0'}
+  /thror@1.0.2:
+    resolution: {integrity: sha512-q92jIDBO9s39Gamn1onZdPCWRbLfsfFSxUqNfgonFVWpJS8TLoCpUKOV3RLRJUq9Kuz4QYnYRRcZfaTFvBA2UA==}
+    engines: {node: '>=18.13.0'}
     dev: false
 
   /typescript@5.3.3:


### PR DESCRIPTION
- Remove `node` and `default` entrypoints.
- Increase minimum version of Node (v20) to use this library.
- Update `drino` peerDependency to fix missing `drino` default's export [drino:109](https://github.com/remscodes/drino/pull/109) and [drino:111](https://github.com/remscodes/drino/pull/111).
- Update `thror` peerDependency to fix usage as CommonJS [thror:9](https://github.com/remscodes/thror/pull/9).